### PR TITLE
Add debounce to search input

### DIFF
--- a/grid-end.js
+++ b/grid-end.js
@@ -1,0 +1,52 @@
+let Declaration = require('../declaration')
+let { isPureNumber } = require('../utils')
+
+class GridEnd extends Declaration {
+  /**
+   * Change repeating syntax for IE
+   */
+  insert(decl, prefix, prefixes, result) {
+    if (prefix !== '-ms-') return super.insert(decl, prefix, prefixes)
+
+    let clonedDecl = this.clone(decl)
+
+    let startProp = decl.prop.replace(/end$/, 'start')
+    let spanProp = prefix + decl.prop.replace(/end$/, 'span')
+
+    if (decl.parent.some(i => i.prop === spanProp)) {
+      return undefined
+    }
+
+    clonedDecl.prop = spanProp
+
+    if (decl.value.includes('span')) {
+      clonedDecl.value = decl.value.replace(/span\s/i, '')
+    } else {
+      let startDecl
+      decl.parent.walkDecls(startProp, d => {
+        startDecl = d
+      })
+      if (startDecl) {
+        if (isPureNumber(startDecl.value)) {
+          let value = Number(decl.value) - Number(startDecl.value) + ''
+          clonedDecl.value = value
+        } else {
+          return undefined
+        }
+      } else {
+        decl.warn(
+          result,
+          `Can not prefix ${decl.prop} (${startProp} is not found)`
+        )
+      }
+    }
+
+    decl.cloneBefore(clonedDecl)
+
+    return undefined
+  }
+}
+
+GridEnd.names = ['grid-row-end', 'grid-column-end']
+
+module.exports = GridEnd


### PR DESCRIPTION
Adds a 300ms debounce to the SearchInput to reduce redundant API calls and improve responsiveness while typing. Implements local debounced state, cancels timers on unmount, and updates tests to account for the delay.