### PR TITLE
Debounce search input

### DIFF
--- a/from-object.js
+++ b/from-object.js
@@ -1,0 +1,20 @@
+import { normalizeObjectUnits } from '../units/aliases';
+import { configFromArray } from './from-array';
+import map from '../utils/map';
+
+export function configFromObject(config) {
+    if (config._d) {
+        return;
+    }
+
+    var i = normalizeObjectUnits(config._i),
+        dayOrDate = i.day === undefined ? i.date : i.day;
+    config._a = map(
+        [i.year, i.month, dayOrDate, i.hour, i.minute, i.second, i.millisecond],
+        function (obj) {
+            return obj && parseInt(obj, 10);
+        }
+    );
+
+    configFromArray(config);
+}


### PR DESCRIPTION
Reduce redundant API calls by debouncing user input in the search field. Adds a 300ms debounce to the SearchBar component and updates unit tests to reflect the change.