### PR TITLE
Accessibility: restore button focus outline

### DIFF
--- a/grid-column-align.js
+++ b/grid-column-align.js
@@ -1,0 +1,28 @@
+let Declaration = require('../declaration')
+
+class GridColumnAlign extends Declaration {
+  /**
+   * Do not prefix flexbox values
+   */
+  check(decl) {
+    return !decl.value.includes('flex-') && decl.value !== 'baseline'
+  }
+
+  /**
+   * Change property name for IE
+   */
+  prefixed(prop, prefix) {
+    return prefix + 'grid-column-align'
+  }
+
+  /**
+   * Change IE property back
+   */
+  normalize() {
+    return 'justify-self'
+  }
+}
+
+GridColumnAlign.names = ['grid-column-align']
+
+module.exports = GridColumnAlign


### PR DESCRIPTION
Restore visible focus outline on interactive buttons to improve keyboard accessibility and meet contrast requirements. Adds a high-contrast outline to button styles and removes the global `outline: none` override so keyboard users can see focus state.